### PR TITLE
specify the platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+/.idea

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OUTPUT = build/image.img
 
 all:
-	DOCKER_BUILDKIT=1 docker build -o build --progress=plain .
-	
+	DOCKER_BUILDKIT=1 docker build --platform linux/amd64 -o build --progress=plain .
+
 run:
 	qemu-system-x86_64 -hda ${OUTPUT} -enable-kvm -smp 4 -m 1G -bios /usr/share/OVMF/x64/OVMF.fd


### PR DESCRIPTION
By specifying the platform, this enables builds on M1 macs to work properly.